### PR TITLE
(pt) Small text fix

### DIFF
--- a/pt/README.md
+++ b/pt/README.md
@@ -3,7 +3,7 @@ http2 explicado
 
 Este é um documento detalhado descrevendo HTTP/2 ([RFC
 7540](https://httpwg.github.io/specs/rfc7540.html)), Os antecedentes, conceitos,
-protocolo and e algo sobre implementações existentes e o que o futuro
+protocolo e algo sobre implementações existentes e o que o futuro
 pode trazer.
 
 Veja http://daniel.haxx.se/http2/ para a casa canônica deste projeto.


### PR DESCRIPTION
Removed the word "and" that has been left behind after the translation to Portuguese.