### PR TITLE
(sv) Correcting minor typos and inconsistency

### DIFF
--- a/sv/part1.md
+++ b/sv/part1.md
@@ -12,7 +12,7 @@ Alla misstag i det är dokumentet är mina egna och resultatet av mina fel. Peka
 gärna ut dem så åtgärdar vi dem till en kommande uppdatering.
 
 I det här dokumentet har jag försökt att konsekvent använda ordet "http2" för
-att bekskriva det nya prokollet, medan det ju rent tekniskt och korrekt
+att bekskriva det nya protokollet, medan det ju rent tekniskt och korrekt
 faktiskt heter HTTP/2. Jag har gjort det valet för läslighetens skull och för att få
 ett bättre flöde i texten.
 
@@ -57,43 +57,43 @@ följer de större förändringarna i de senaste versionerna.
 ### Version 1.13
 
 - Converted the master version of this document to Markdown syntax
-- 13: Mention more resources, updated links and descriptions 
-- 12: Updated the QUIC description with reference to draft 
-- 8.5: Refreshed with current numbers 
-- 3.4: The average is now 40 TCP connections 
-- 6.4: Updated to reflect what the spec says 
+- 13: Mention more resources, updated links and descriptions
+- 12: Updated the QUIC description with reference to draft
+- 8.5: Refreshed with current numbers
+- 3.4: The average is now 40 TCP connections
+- 6.4: Updated to reflect what the spec says
 
 ### Version 1.12
 
-- 1.1: HTTP/2 is now in an official RFC 
-- 6.5.1: Link to the HPACK RFC 
-- 9.1: Mention the Firefox 36+ config switch for http2 
-- 12.1: Added section about QUIC 
+- 1.1: HTTP/2 is now in an official RFC
+- 6.5.1: Link to the HPACK RFC
+- 9.1: Mention the Firefox 36+ config switch for http2
+- 12.1: Added section about QUIC
 
 ### Version 1.11
 
-- Lots of language improvements mostly pointed out by friendly contributors 
-- 8.3.1: Mention nginx and Apache httpd specific acitivities 
+- Lots of language improvements mostly pointed out by friendly contributors
+- 8.3.1: Mention nginx and Apache httpd specific acitivities
 
 ### Version 1.10
 
-- 1: The protocol has been “okayed” 
-- 4.1: Refreshed the wording since 2014 is last year 
-- Front: Added image and call it “http2 explained” there, fixed link 
-- 1.4: Added document history section 
-- Many spelling and grammar mistakes corrected 
-- 14: Added thanks to bug reporters 
-- 2.4: Better labels for the HTTP growth graph 
-- 6.3: Corrected the wagon order in the multiplexed train 
-- 6.5.1: HPACK draft-12 
+- 1: The protocol has been “okayed”
+- 4.1: Refreshed the wording since 2014 is last year
+- Front: Added image and call it “http2 explained” there, fixed link
+- 1.4: Added document history section
+- Many spelling and grammar mistakes corrected
+- 14: Added thanks to bug reporters
+- 2.4: Better labels for the HTTP growth graph
+- 6.3: Corrected the wagon order in the multiplexed train
+- 6.5.1: HPACK draft-12
 
 ### Version 1.9
 
-- Updated to HTTP/2 draft-17 and HPACK draft-11  
-- Added section "10. http2 in Chromium" (== one page longer now)  
-- Lots of spell fixes  
-- At 30 implementations now  
-- 8.5: Added some current usage numbers  
-- 8.3: Mention internet explorer too  
-- 8.3.1 Added "missing implementations"  
+- Updated to HTTP/2 draft-17 and HPACK draft-11
+- Added section "10. http2 in Chromium" (== one page longer now)
+- Lots of spell fixes
+- At 30 implementations now
+- 8.5: Added some current usage numbers
+- 8.3: Mention internet explorer too
+- 8.3.1 Added "missing implementations"
 - 8.4.3: Mention that TLS also increases success rate

--- a/sv/part11.md
+++ b/sv/part11.md
@@ -8,7 +8,7 @@ används ofta som ett testverktyg och en utforskares sätt att peka på
 webbsajter och vi tänker fortsätta med det för http2 också.
 
 curl använder det separata biblioteket [nghttp2](https://nghttp2.org/) för all
-funktionalitet i http2-lagret. curl kräver nghttp2 1.0 är senare.
+funktionalitet i http2-lagret. curl kräver nghttp2 1.0 eller senare.
 
 Notera att just nu skippas curl på linux inte alltid med http2-support
 påslaget.
@@ -16,17 +16,17 @@ påslaget.
 ## 11.1. HTTP 1.x-liknande
 
 curl konverterar inkommande http2-headrar till HTTP 1.x-liknande headers och
-skicka dem till användaren, så att de kommer vara väldigt lika de i
+skickar dem till användaren, så att de kommer vara väldigt lika de i
 existerande HTTP. Det skapar en enkel övergång för vadsomhelst som använder
 curl och HTTP idag. På sammas sätt konverterar curl utgående headrar. Ge dem
 till curl i HTTP 1.x-stil och den gör om dem automatiskt när den pratar med
-http2-servrar. Det låter också använder att inte behöva bry sig så mycket om
+http2-servrar. Det låter också användare att inte behöva bry sig så mycket om
 vilken specifik HTTP version som faktiskt används över kabeln.
 
 ## 11.2. Klartext, osäkert
 
 curl stöder http2 över vanlig TCP mha Upgrade:-headern. Om du gör en
-HTTP-request och ber om http2, kommer curl be server att uppdatera kopplet
+HTTP-request och ber om http2, kommer curl be servern att uppdatera kopplet
 till http2 om det är möjligt.
 
 ## 11.3. TLS och vilka bibliotek
@@ -67,7 +67,7 @@ applikation kan mycket väl starta ett antal överföringar samtidigt och ifall
 du då hellre vill att libcurl ska vänta lite för att köra alla över samma
 koppel istället för att starta nya koppel för alla, så använder du
 [CURLOPT_PIPEWAIT-optionen](https://curl.haxx.se/libcurl/c/CURLOPT_PIPEWAIT.html)
-för varje individuell överföringing du hellre vill ska vänta.
+för varje individuell överföring du hellre vill ska vänta.
 
 ### 11.5.3 Server push
 
@@ -75,5 +75,5 @@ libcurl 7.44.0 och senare stöder HTTP/2 server push. Du kan dra nytta av den
 funktionen genom att sätta upp en push callback med
 [CURLMOPT_PUSHFUNCTION-optionen](https://curl.haxx.se/libcurl/c/CURLMOPT_PUSHFUNCTION.html). Om
 "pushen" accepteras av applikationen kommer den skapa en ny överföring som en
-CURL easy handle och leverera data över den, precis som vilken annan
+curl easy handle och leverera data över den, precis som vilken annan
 överföring som helst.

--- a/sv/part12.md
+++ b/sv/part12.md
@@ -4,7 +4,7 @@ En hel del tuffa beslut och kompromisser gjordes för http2. När http2
 driftsätts finns det ett etablerat sätt att uppgradera till andra
 protokoll-versioner och det arbetet är ett fundament för att göra fler
 protokollrevisioner framöver. Det tar också in ett medvetande och en
-infrastruktur som kan hantera flera olika versioner parallelt. Kanske behöver
+infrastruktur som kan hantera flera olika versioner parallellt. Kanske behöver
 vi inte fasa ut det gamla helt när vi introducerar nytt?
 
 http2 har fortfarnade en massa gammal HTTP 1-"legacy" med sig i bagaget som
@@ -30,6 +30,6 @@ att lösa.
 QUIC är än så länge bara implementerat av Google i Chrome och deras servrar,
 och den koden är inte lätt att återanvända på andra ställen, även om det finns
 ett [libquic](https://github.com/devsisters/libquic) som försöker precis det.
-Protokollet har skrivits ner som en [internet
+Protokollet har skrivits ner som en [Internet
 draft](https://tools.ietf.org/html/draft-tsvwg-quic-protocol-01) inom IETFs
 transportarbetsgrupp.

--- a/sv/part13.md
+++ b/sv/part13.md
@@ -1,6 +1,6 @@
 # 13. Fortsatt läsning
 
-Om du tycker att det här dokumentet var lite tunt på innehåll eller tekniska 
+Om du tycker att det här dokumentet var lite tunt på innehåll eller tekniska
 detaljer så finner du ytterligare resurser att främja din nyfikenhet här nedan:
 
 - HTTPbis-arbetsgruppens e-postlista samt dess arkiv: https://lists.w3.org/Archives/Public/ietf-http-wg/

--- a/sv/part14.md
+++ b/sv/part14.md
@@ -1,12 +1,12 @@
 # 14. Tack
 
-Inspiration och paketformatbilden i Lego kommer från Mark Nottingham. 
+Inspiration och paketformatbilden i Lego kommer från Mark Nottingham.
 
 HTTP trenddata kommer från https://httparchive.org/.
 
 RTT-graferna kommer från presentationer av Mike Belshe.
 
-Mina barn Agnes och Rex för att dom låtit mig låna deras Legofigurer för "head 
+Mina barn Agnes och Rex för att dom låtit mig låna deras Legofigurer för "head
 of line"-bilden.
 
 Tack till följande vänner för granskning och kommentarer: Kjell Ericson, Bjorn
@@ -14,7 +14,7 @@ Reese, Linus Swälas och Anthony Bryan. Er hjälp har varit mycket uppskattad
 och har verkligen förbättrat dokumentet!
 
 Under olika iterationer har följande vänliga människor rapporterat diverse
-felaktigheter och gjort förbättringar av dokumentet: Mikael Olsson, Remi 
-Gacogne, Benjamin Kircher, saivlis, florin-andrei-tp, Brett Anthoine, Nick 
-Parlante, Matthew King, Nicolas Peels, Jon Forrest, sbrickey, Marcin Olak, 
+felaktigheter och gjort förbättringar av dokumentet: Mikael Olsson, Remi
+Gacogne, Benjamin Kircher, saivlis, florin-andrei-tp, Brett Anthoine, Nick
+Parlante, Matthew King, Nicolas Peels, Jon Forrest, sbrickey, Marcin Olak,
 Gary Rowe, Ben Frain, Mats Linander, Raul Siles, Alex Lee, Richard Moore.

--- a/sv/part2.md
+++ b/sv/part2.md
@@ -31,7 +31,7 @@ Senare skapade detta interoperabilitetsproblem när klienter och servrar väl
 började använda såna funktioner. HTTP pipelining är kanske det främsta exempel
 på en sådan funktion.
 
-## 2.3 Otillräcklig nyttjande av TCP
+## 2.3 Otillräckligt nyttjande av TCP
 
 HTTP 1.1 har svårt att verkligen till fullo nyttja all kraft och den prestanda
 som TCP erbjuder. HTTP-klienter och webbläsare måste vara väldigt kreativa för
@@ -57,7 +57,7 @@ varje sida.
 Som diagramet nedan visar, så har trenden pågått ett tag och det finns inga
 indikationer på att den kommer ändras inom kort. Den visar tillväxten av
 överföringsstorlek (i grönt) och det totala antalet förfrågningar som använts
-i genomsnit (i rött) för att visa de mest populära webbsajterna i världen, och
+i genomsnitt (i rött) för att visa de mest populära webbsajterna i världen, och
 hur det har förändrats de senaste fyra åren.
 
 ![transfer size growth](https://raw.githubusercontent.com/bagder/http2-explained/master/images/transfer-size-growth.png)
@@ -72,7 +72,7 @@ stor andel av användarna.
 
 Medan vi sett en rejäl ökning i tillgänglig bandbredd hos människor över de
 senaste åren, så har vi inte sett samma förbättring i att minska
-fördröjningar.  Länkar med stora fördröjningar, som många nuvarande mobila
+fördröjningar. Länkar med stora fördröjningar, som många nuvarande mobila
 teknologier, gör det riktigt svårt att få en bra och snabb upplevelse av
 webben, även om du har en riktigt hög bandbredd på uppkopplingen.
 
@@ -83,7 +83,7 @@ inte bara är en på förhand genererad ström att skicka ut.
 ## 2.6. Först-i-kön-blockering
 
 HTTP Pipelining är ett sätt att skicka en till förfrågan till servern medan
-klienten fortfarande väntar på svaret till den förra frågningen. Det är
+klienten fortfarande väntar på svaret på den förra frågan. Det är
 väldigt likt en kö på banken eller till kassan i en mataffär. Du vet helt
 enkelt inte om personen framför dig i kön är en snabb kund eller den där
 irriterande personen som kommer ta en evighet innan hon/han är klar:
@@ -97,7 +97,7 @@ gör så kan du inte undvika att ta ett beslut och när det väl är taget kan d
 inte byta kö.
 
 Skapa nya köer är också belagt med prestanda- och resurs-förluster så det
-skalar inte bra upp till mer än ett ganska lågt antal köer. Det finns helt
+skalar inte upp bra till mer än ett ganska lågt antal köer. Det finns helt
 enkelt ingen perfekt lösning för detta.
 
 Även idag, 2015, så har de flesta desktop-webbläsare HTTP pipelining avslaget

--- a/sv/part3.md
+++ b/sv/part3.md
@@ -21,7 +21,7 @@ där.
 
 ## 3.2 Inlining
 
-Inlining är ett annat trick där man underviker skicka enskilda bilder, och det
+Inlining är ett annat trick där man underviker att skicka enskilda bilder, och det
 gör man genom att använda data: URLer inbäddade i CSS-filen. Det har liknande
 nackdelar som i spriting-fallet ovan.
 
@@ -36,10 +36,10 @@ nackdelar som i spriting-fallet ovan.
 ## 3.3 Concatenation
 
 En stor sajt kan lätt hamna i en situation med väldigt många olika
-javascriptfiler.  Frontendverktyg kan hjälpa utvecklarna att slå ihop varenda
+javascriptfiler. Frontendverktyg kan hjälpa utvecklarna att slå ihop varenda
 en av dem till en enda stor klump så att webbläsaren hämtar en enda stor fil
 istället för dussintals mindre filer. För mycket data skickas därmed när
-enbart lite behvös. För mycket data laddas om när en enda ändring behövs.
+enbart lite behövs. För mycket data laddas om när en enda ändring behövs.
 
 Den här övningen är förstås mest besvärlig för de involverade utvecklarna.
 
@@ -59,7 +59,7 @@ många fler koppel till din sajt och minska sidladdningstider.
 koppel per hostnamn, men de behöver fortfarande ha någon gräns så sajter
 fortsätter att använda den här tekniken för att öka antalet koppel. Med ett
 ständigt ökande antal objekt (som jag visade tidigare) så måste ett än större
-antalet koppel användas för att få HTTP att prestera bra och göra din sajt
+antal koppel användas för att få HTTP att prestera bra och göra din sajt
 snabb. Det är inte ovanligt att enskilda sajter använder långt över 50 eller
 upp och förbi 100 koppel tack vare den här tekniken. Färsk statistik från
 httparchive.org visar att av de 300 000 mest populära URLerna i världen så

--- a/sv/part4.md
+++ b/sv/part4.md
@@ -51,7 +51,7 @@ som i fallet för HTTP 1.1.
 
 [SPDY](https://en.wikipedia.org/wiki/SPDY) är ett protokoll som utvecklades och
 togs fram av Google. De utvecklade det visserligen öppet och bjöd in alla som
-vill att delta, men det var tydligt att de utnyttjade sin situation med att
+ville att delta, men det var tydligt att de utnyttjade sin situation med att
 kontrollera både en populär webbläsare och ett signifikant server-bestånd med
 välanvända tjänster.
 

--- a/sv/part5.md
+++ b/sv/part5.md
@@ -66,7 +66,7 @@ uppfattningen att allt som går över port 80 är HTTP 1.1 och det får en del
 mellan-boxar att blanda sig i och förstöra trafik när det faktiskt är något
 annat protokoll som pratas där.
 
-Obligatorisk TLS är ett ämne som orsakat en mycket handviftande och upprörda
+Obligatorisk TLS är ett ämne som orsakat mycket handviftande och upprörda
 röster på mailinglistor och möten - är det bra eller är det ondska? Det är ett
 infekterat ämne - var medveten om detta när du kastar den här frågan i
 ansiktet på en HTTPbis-deltagare!
@@ -81,7 +81,7 @@ finns krav på vilka chiffer som måste användas.
 ## 5.3. http2-förhandling över TLS
 
 Next Protocol Negotiation (NPN), är tillägget som användes i SPDY för att
-förhandla med TLS-servrar.  Eftersom det inte var en riktig standard så togs
+förhandla med TLS-servrar. Eftersom det inte var en riktig standard så togs
 det till IETF och igenom och det som kom ut blev ALPN: Application Layer
 Protocol Negotiation. ALPN är det som nu lyfts upp för att användas i http2,
 medan SPDY-klienter och -servrar fortsätter använda NPN.

--- a/sv/part6.md
+++ b/sv/part6.md
@@ -22,7 +22,7 @@ implementationer mycket enklare.
 Dessutom gör det det mycket lättare att separera själva protokolldelarna från
 inramningen - vilket var förvirrande blandat i HTTP1.
 
-Det faktum att protokollet har komprimering och ofta kommer körs över TLS
+Det faktum att protokollet har komprimering och ofta kommer köras över TLS
 minskar också värdet av text eftersom man inte skulle se text över kabeln i
 alla fall. Vi måste helt enkelt vänja oss vid tanken på att använda en
 Wireshark-inspector eller liknande för att lista ut exakt vad som pågår på
@@ -48,7 +48,7 @@ HEADERS. Jag kommer beskriva några av paket-typerna i närmare detaljer nedan.
 ## 6.3. Multiplexade strömmar
 
 Ström-id som nämndes i stycket ovan om det binära formatet, gör att varje
-paket som kommer över http2 är associerad med en "ström". En ström är en
+paket som kommer över http2 är associerat med en "ström". En ström är en
 logisk förbindelse. En oberoende, bi-direktionell sekvens av paket som utbytes
 mellan klienten och servern inom ett http2-koppel.
 
@@ -69,7 +69,7 @@ De två tågen multiplexade över samma koppel:
 
 ![multiplexat tåg](https://raw.githubusercontent.com/bagder/http2-explained/master/images/train-multiplexed.jpg)
 
-## 6.4. Prioriteter och beroendeen
+## 6.4. Prioriteter och beroenden
 
 Varje ström har också en prioritet (även känd som "vikt"), vilken används för
 att berätta för andra sidan vilka strömmar som skall anses viktigast ifall
@@ -94,7 +94,7 @@ den frågan utan att servern ska behöva mellanlagra info eller meta-data från
 tidigare förfrågningar. Eftersom http2 inte ändra några sådana paradigmer så
 måste det också fungera så.
 
-Detta gör HTTP repetitivt. När en klient frågar efter många resurser från
+Detta gör HTTP repetativt. När en klient frågar efter många resurser från
 samma server, typ bilder på en webbsida, så kommer det göras en lång serie med
 förfrågningar som ser nästan identiska ut. En serie med nästan identiska
 någonting ber om komprimering.

--- a/sv/part7.md
+++ b/sv/part7.md
@@ -16,9 +16,9 @@ diskuterats för att inkluderas i protokollet och som troligen tillhör de
 första typerna att skickas som utökningar. Jag beskriver dem här bara på grund
 deras popularitet och deras tidigare roll som "inhemska" typer.
 
-## 7.1. Alternativa Tjänster
+## 7.1. Alternativa tjänster
 
-När http2 antas, finns det anledning att misstänk att TCP-koppel kommer bli
+När http2 antas, finns det anledning att misstänka att TCP-koppel kommer bli
 mycket långvariga och hållas levande mycket längre än vad HTTP 1.x-kopper
 någonsin hållits. En klient bör kunna göra mycket av vad den vill över ett
 enda koppel per varje host/sajt och det enda kopplet kan då potentiellt hållas

--- a/sv/part8.md
+++ b/sv/part8.md
@@ -12,7 +12,7 @@ http2 minskar antalet turer fram och tillbaks över nätverket och det undviker
 först-i-kön-blockeringsproblemen genom att multiplexa och att kunna avsluta
 oönskad strömmar snabbt.
 
-Det tillåter ett stort antal paralella strömmar som i antal vida överstiger
+Det tillåter ett stort antal parallella strömmar som i antal vida överstiger
 antal koppel host även de mest shardade sajterna av idag.
 
 Med prioriteter använda ordentligt på strömmarna finns chansen att klient
@@ -79,7 +79,7 @@ har alla släppt http2-kapabla open source-servrar.
 
 ### 8.3.1. Saknade implementationer
 
-De två otroligt populära servrarna Apache HTTPD och Nnginx har båda erbjudit
+De två otroligt populära servrarna Apache HTTPD och Nginx har båda erbjudit
 SPDY support. Den 22:a september 2015 kom så Nginx med sin första version med
 officiell support för http2. Nginx har släppt
 ["nginx-1.9.5"](https://www.nginx.com/blog/nginx-1-9-5/) och http2-modulen för
@@ -105,7 +105,7 @@ som kunde göras.
 
 Google har
 [annonserat](https://blog.chromium.org/2015/02/hello-http2-goodbye-spdy.html)
-att de kommer ta bort support för SPDY och NPN i Chrom under 2016 och de
+att de kommer ta bort support för SPDY och NPN i Chrome under 2016 och de
 uppmanar servrar att migrera till http2 istället.
 
 ### 8.4.2. “Protokollet är endast användbart för webbläsare"
@@ -166,7 +166,7 @@ TLS-handskakningar och därmed prestera bättre än HTTPS skulle göra för HTTP
 
 Ja, vi gillar att se protokoll i klartext eftersom det gör debuggning och
 spårning enklare. Men text-baserade protokoll är också mer felbenägna och
-öppar upp för mycket mer parsning och fler parsningsproblem.
+öppnar upp för mycket mer parsning och fler parsningsproblem.
 
 Om du verkligen inte kan hantera ett binärt protokoll, så kan du inte hantera
 TLS och komprimering i HTTP 1.1 heller och det har funnits där och används
@@ -191,7 +191,7 @@ kan indikera att http2 håller sina löften.
 
 Seriöst, är det ditt argument? Lager är inte heliga oberörbara pelare i en
 global religion och om vi har klivit över inpå en del gråzoner när vi gjorde
-http2 så har det varit med avsikten att göra ett bra och effektivt protikoll
+http2 så har det varit med avsikten att göra ett bra och effektivt protokoll
 inom de givna ramarna.
 
 ### 8.4.8. “Det fixar inte flera av HTTP 1.1s problem"
@@ -201,7 +201,7 @@ det flera gamla HTTP funktioner som var tvugna att finnas kvar. Som t.ex
 headers och därmed också de ofta ogillade cookiesarna, authorization-headrar
 och mer. Men med fördelen att genom att behålla dessa paradigmer fick vi ett
 protokoll som det är möjligt att driftssätta utan att kräva en helt otänkbar
-mängd uppgraderingsarbete där fundamentala deras måste ersättas eller skrivas
+mängd uppgraderingsarbete där fundamentala delar måste ersättas eller skrivas
 om. http2 är i grund och botten bara ett ny inramning ("framing layer").
 
 ## 8.5. Kommer http2 att driftssättas vitt och brett?
@@ -209,8 +209,8 @@ om. http2 är i grund och botten bara ett ny inramning ("framing layer").
 Det är för tidigt att säga säkert, men jag kan ändå gissa och estimera och det
 är vad jag kommer göra här.
 
-Nejsägarna kommer säga "kolla hur bra IPv6 har gjort ifrån sig" som ett
-exempel på ett protokoll som det tagit decenier bara för att böra bli
+Nej-sägarna kommer säga "kolla hur bra IPv6 har gjort ifrån sig" som ett
+exempel på ett protokoll som det tagit decennier bara för att börja bli
 driftsatt brett. http2 är inte en IPv6 dock. Det här är ett protokoll ovanpå
 TCP som använder vanliga HTTP-uppgraderingsmekanismer, portnummer och TLS
 etc. Det kommer inte kräva att de flesta routers eller brandväggar ändras
@@ -225,7 +225,7 @@ idag använder SPDY.
 
 http2, baserat på samma principer som SPDY, skulle jag säga kommer sannolikt
 driftsättas ännu mer eftersom det är ett IETF-protokoll. SPDY-användningen hölls
-alltid tillbaks en del av dess "det är ett Google-protkoll"-stigma.
+alltid tillbaks en del av dess "det är ett Google-protokoll"-stigma.
 
 Det finns flera stora webbläsare bakom utrullningen. Representanter från
 Firefox, Chrome, Safari, Internet Explorer och Opera har sagt att de kommer
@@ -234,14 +234,14 @@ skeppa http2-kapabla webbläsare och de har visat fungerande implementaitoner.
 Det finns flera stora server-operatörer som är sannolika att erbjuda http2
 snart, inklusive Google, Twitter och Facebook och vi hoppas få se att
 http2-support snart läggs till i populära server-implementationer som Apache
-HTTPD och nginx. H2o är en ny vrålsnabb HTTP-server med http2-stöd som visar
+HTTPD och Nginx. H2o är en ny vrålsnabb HTTP-server med http2-stöd som visar
 potential.
 
-Några av de störa proxy-tillverkarna, inklusive HAProxy, Squid och Varnish har
+Några av de största proxy-tillverkarna, inklusive HAProxy, Squid och Varnish har
 uttalat sina intentioner att stödja http2.
 
 Allt igenom 2015 har mängden http2-trafik ökat. I början av September visade
 användningen av Firefox 40 http2 i 13% av all HTTP-trafik och 27% av all
-HTTPS-trafik, medan Google ser HTTP/2 i ungefär 18% av sin inkommande
+HTTPS-trafik, medan Google ser http2 i ungefär 18% av sin inkommande
 trafik. Det kan noteras att Google driver andra experiment med nya protokoll
 (Se QUIC i 12.1) vilket ger lägre http2-nivåer än det annars kunde vara.

--- a/sv/part9.md
+++ b/sv/part9.md
@@ -2,10 +2,10 @@
 
 Firefox har varit hack-i-häl med draftarna och har erbjudit
 http2-testimplemenationer under många månader. Under utvecklingen av
-http2-protkollet har klienter och servrar måste komma överrens om vilken
-draft-version av prokollet de implementerat vilket har gjort det lite lätt
-irriterande att köra tester. Vara bara medveten och kontrollera att din klient
-och server är överrens om vilken protokoll-draft de implementerar.
+http2-protkollet har klienter och servrar måste komma överens om vilken
+draft-version av protokollet de implementerat vilket har gjort det lite lätt
+irriterande att köra tester. Var bara medveten och kontrollera att din klient
+och server är överens om vilken protokoll-draft de implementerar.
 
 ## 9.1. Först, se till att det är påslaget
 
@@ -28,7 +28,7 @@ http2 i aktion när du går till https://-sajter som erbjuder http2.
 
 ![transparant http2-användning](https://raw.githubusercontent.com/bagder/http2-explained/master/images/firefox-screenshot.png)
 
-Det finns inget gränssnitselement någonstans som berättar att du pratar
+Det finns inget gränssnittselement någonstans som berättar att du pratar
 http2. Du kan helt enkelt inte enkelt se det. Ett sätt att lista ut det är att
 välja “Web developer->Network” och kontrollera svars-headrar och se vad du
 fick tillbaks från servern. Svaret är “HTTP/2.0”-någonting och Firefox stoppar


### PR DESCRIPTION
Read through the document and discovered a few typos and such. 

I see that my text editor automatically removed some spaces at the end of lines especially in Part1, which is cluttering the commit a bit. I can remove those changes if they are bothering.

I found some sentences i couldn't figure out what they were supposed to say, so i left them untouched.
But i will list them here for the author to maybe look at. 

Part5 - heading "5.3. http2-förhandling över TLS"

"ALPN skiljer sig i huvudsak från NPN genom vet det är som bestämmer vilket
protokoll som pratas."

Part6 - heading "6.4. Prioriteter och beroenden"

"Detta möjliggör för en klient att bygga ett
"träd" med prioriteter där flera "barn-strömmar" kan bero att
"föräldra-strömmar" först avslutas."

Part 6 - heading "6.5.1. Komprimering är ett lurigt ämne"

"HTTPS- och SPDY-komprimering befanns vara känsliga för"

Part8 - heading "8.4.4. “Dess användning av TLS gör den långsammare""

"Experiment har visat att genom att använda TLS så får man en högre grad av
framgång än när man implementerar ny klartext-protokoll över port 80, eftersom
det finns lite för många mellan-boxar där ute i världen som ingriper i det som
de tror är HTTP 1.1 om det kommer över port och ibland kan se ut som HTTP."