### PR TITLE
adjust fonts for Japanese

### DIFF
--- a/ja/book.json
+++ b/ja/book.json
@@ -1,0 +1,8 @@
+{
+    "gitbook": ">=2.0.0",
+    "title": "http2 explained",
+    "pdf": {
+        "fontSize": 14,
+        "fontFamily": "IPAGothic"
+    }
+}


### PR DESCRIPTION
The current fonts have been wrongly a Chinese font.
Adjusted the fonts as had been worked in http3-explained's issue: [A better font would be good for Japanese](https://github.com/bagder/http3-explained/issues/32).
